### PR TITLE
Fooled with device rotations.

### DIFF
--- a/Betas/field_mode/demo.html
+++ b/Betas/field_mode/demo.html
@@ -91,16 +91,16 @@ input{
 <input id="gamma" type="range" min="-180" max="180">
 <label for="gamma">gamma(Y)</label>
 
-<h2>Velocity</h2>
+<h2>Force</h2>
 
-<input id="Vx" type="range" min="-100" max="100">
-<label for="Vx">Vx</label>
+<input id="Fx" type="range" min="-100" max="100">
+<label for="Fx">Fx</label>
 
-<input id="Vy" type="range" min="-100" max="100">
-<label for="Vy">Vy</label>
+<input id="Fy" type="range" min="-100" max="100">
+<label for="Fy">Fy</label>
 
-<input id="Vz" type="range" min="-100" max="100">
-<label for="Vz">Vz</label>
+<input id="Fz" type="range" min="-100" max="100">
+<label for="Fz">Fz</label>
 
 <script src="position.js"></script>
 </body>

--- a/Betas/field_mode/position.js
+++ b/Betas/field_mode/position.js
@@ -31,23 +31,34 @@ var METALGEAR = METALGEAR || {};
 		alert("This browser sucks.");
 	}
 
+	var initialOrientation = null;
+
 	METALGEAR.handleOrientation = function(_orientation){
 	//	console.log('orientation:', _orientation);
 		METALGEAR.orientation = _orientation;
 
-		document.getElementById('heading').value = _orientation.webkitCompassHeading;
-		document.getElementById('alpha').value = _orientation.alpha;
-		document.getElementById('beta').value = _orientation.beta;
-		document.getElementById('gamma').value = _orientation.gamma;
+		if (initialOrientation === null) {
+			initialOrientation = _orientation;
+		}
 
-		//turntable.style.webkitTransform = 'rotateX('+_orientation.beta+'deg) rotateY('+_orientation.webkitCompassHeading+'deg)';
+		var deviceRoll = _orientation.alpha - initialOrientation.alpha;
+		var devicePitch = _orientation.beta - initialOrientation.beta;
+		var deviceYaw = _orientation.gamma - initialOrientation.gamma;
+		var deviceHeading = _orientation.heading - initialOrientation.heading;
+
+		document.getElementById('heading').value = deviceHeading;
+		document.getElementById('alpha').value = deviceRoll;
+		document.getElementById('beta').value = devicePitch;
+		document.getElementById('gamma').value = deviceYaw;
+
+		//turntable.style.webkitTransform = 'rotateX('+beta+'deg) rotateY('+webkitCompassHeading+'deg)';
 		var orientation_style = '';
-		if(window.orientation === -90){ //right
-			orientation_style += 'translateZ(200px) rotateZ('+(_orientation.beta)+'deg) rotateX('+(_orientation.gamma-90)+'deg) rotateY('+(_orientation.webkitCompassHeading-90)+'deg)';
-		}else if(window.orientation === 90){ //left
-			orientation_style += 'translateZ(200px) rotateZ('+(-_orientation.beta)+'deg) rotateX('+(180-_orientation.gamma+90)+'deg) rotateY('+(_orientation.webkitCompassHeading+90)+'deg)';
+		if(window.orientation === -90){ // home button on right
+			orientation_style += 'translateZ(200px) rotateZ('+(deviceRoll)+'deg) rotateX('+(deviceYaw)+'deg) rotateY('+(devicePitch)+'deg)';
+		}else if(window.orientation === 90){ // home button on left
+			orientation_style += 'translateZ(200px) rotateZ('+(deviceRoll)+'deg) rotateX('+(-deviceYaw)+'deg) rotateY('+(-devicePitch)+'deg)';
 		}else{
-			orientation_style += 'translateZ(200px) rotateX('+(_orientation.beta)+'deg) rotateY('+_orientation.webkitCompassHeading+'deg)';
+			orientation_style += 'translateZ(200px) rotateZ('+(deviceRoll)+'deg) rotateY('+(-deviceYaw)+'deg) rotateX('+(devicePitch)+'deg)';
 		}
 
 		turntable.style.webkitTransform = orientation_style;
@@ -71,9 +82,9 @@ var METALGEAR = METALGEAR || {};
 
 	METALGEAR.handleMotion = function(_motion){
 		METALGEAR.motion = _motion;
-		document.getElementById('Vx').value = _motion.acceleration.x * 100;
-		document.getElementById('Vy').value = _motion.acceleration.y * 100;
-		document.getElementById('Vz').value = _motion.acceleration.z * 100;
+		document.getElementById('Fx').value = _motion.acceleration.x * 100;
+		document.getElementById('Fy').value = _motion.acceleration.y * 100;
+		document.getElementById('Fz').value = _motion.acceleration.z * 100;
 	};
 
 	if(!!window.DeviceMotionEvent){


### PR DESCRIPTION
This demo ignores the compass heading, partly because it's often wildly inaccurate on iPhones but mainly because it's not going to be orthogonal with the other rotation axes. Gimbal locking is still a problem, but I think it works properly within the first 90 degrees, at least if you start with the device flat on a table.

A better solution for full-frame arbitrary rotations is to convert alpha, beta, gamma into quaternion form. That's a huge huge pain but it … may? Solve gimbal locking?

Also, the accelerometer delivers forces, not velocities. These were mislabed as Vx,y,z on the demo page. You can time-integrate them if you do want velocity, but that's probably not going to be robust.
